### PR TITLE
Support for arbitrary filament codes/settings

### DIFF
--- a/bambulabs_api/filament_info.py
+++ b/bambulabs_api/filament_info.py
@@ -26,8 +26,37 @@ class AMSFilamentSettings:
     nozzle_temp_max: int
     tray_type: str
 
+class Filament(AMSFilamentSettings):
+    """Changes the behavior of the Filament library class to allow unknown/new filaments (tray_info_idx codes) to be set. 
+    Does not validate manually-set the filament codes against a known list, but printer should just safely/silently ignore it if it's not real"""
 
-class Filament(AMSFilamentSettings, Enum):
+    def __init__(self, filament: str | AMSFilamentSettings):
+        
+        # Support existing lookup by standard filament names known to the library
+        if type(filament) is str:
+            name = filament 
+            print(name)
+            
+            # This will throw an exception if the name can't be mapped to a known setting, just like before
+            knownF = FilamentEnum(name)
+            
+            super(Filament, self).__init__(
+                knownF.tray_info_idx,
+                int(knownF.nozzle_temp_min),
+                int(knownF.nozzle_temp_max),
+                knownF.tray_type,
+                )
+        
+        # Support creating your own arbitrary AMSFilamentSettings so newer/custom codes can be used
+        else:
+            super(Filament, self).__init__(
+                filament.tray_info_idx,
+                int(filament.nozzle_temp_min),
+                int(filament.nozzle_temp_max),
+                filament.tray_type,
+                )
+
+class FilamentEnum(AMSFilamentSettings, Enum):
     """
     Enum class for the filament settings
 


### PR DESCRIPTION
The current internal list of [filament codes](https://github.com/BambuTools/bambulabs_api/blob/1a6f06e0febd0956614c3c196495add6196f1fd8/bambulabs_api/filament_info.py#L30) is missing a lot of newer stuff that has been [put out by Bambu](https://github.com/bambulab/BambuStudio/tree/5f1714f02ceeb34519e0ec401d37be3ff7efa87b/resources/profiles/BBL/filament). Although you can build a custom AMSFilamentSettings object with any `tray_info_idx` value, you can't actually submit them to the printer because the current code tries to turn that into a Filament object and panics when it can't find a matching code. 

This pull request changes the Filament class to allow arbitrary filament codes (`tray_info_idx` values, when the `filament` argument is an AMSFilamentSettings object) to be used, while still retaining the old behavior if a filament name string is used instead, which still requires a code lookup. Based on my testing the printer will just silently ignore unknown `tray_info_idx` values you send it, so there shouldn't be any harm in letting those go through without validating them first. 

This approach also has the benefit of supporting custom filament profiles, which is not possible with the current Enum-based class even if it's kept up-to-date with Bambu's list. 

I've only tested this change on my A1 with AMS Lite, and only for setting and retrieving tray settings. I don't think it would break anything else since it still offers the same working functionality as before, but obviously that should be verified. 