### PR TITLE
fix: Update `mqtt_start` docstring and return client code

### DIFF
--- a/bambulabs_api/client.py
+++ b/bambulabs_api/client.py
@@ -95,15 +95,13 @@ class Printer:
 
     def mqtt_start(self):
         """
-        Start the camera
+        Start the mqtt client
 
-        Returns
-        -------
-        bool
-            If the camera successfully connected
+        Returns:
+            MQTTErrorCode: error code of loop start
         """
         self.mqtt_client.connect()
-        self.mqtt_client.start()
+        return self.mqtt_client.start()
 
     def mqtt_stop(self):
         """


### PR DESCRIPTION
While going through the source code of this repository I noticed the docstring for the `mqtt_start` function is copied from the previous `camera_start` function.

I updated the docstring to reflect the function's purpose and modified the body to return the client start code.