### PR TITLE
support shared tls session for ftp

### DIFF
--- a/bambulabs_api/ftp_client.py
+++ b/bambulabs_api/ftp_client.py
@@ -19,6 +19,15 @@ class ImplicitFTP_TLS(ftplib.FTP_TLS):
         super().__init__(*args, **kwargs)
         self._sock = None
 
+    """Explicit FTPS, with shared TLS session"""
+    def ntransfercmd(self, cmd, rest=None):
+        conn, size = ftplib.FTP.ntransfercmd(self, cmd, rest)
+        if self._prot_p:
+            conn = self.context.wrap_socket(conn,
+                                            server_hostname=self.host,
+                                            session=self.sock.session)
+        return conn, size
+
     @property
     def sock(self):
         """Return the socket."""


### PR DESCRIPTION
Solution is copied from [this stackoverflow answer](https://stackoverflow.com/questions/14659154/ftps-with-python-ftplib-session-reuse-required/43301750#43301750)